### PR TITLE
Setup base project and support to manage AWS resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Node
+npm-debug.log
+dist/
+
+# Vagrant
+.vagrant
+
+# Ansible
+deployment/ansible/roles/azavea.*
+deployment/ansible/*.retry
+
+# Terraform
+deployment/terraform/.terraform
+*.tfstate
+*.tfplan

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2016 Stroud Water Research Center
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# mmw-micro
+
+A static micro site storm model.
+
+### Requirements
+
+* Vagrant 1.8+
+* VirtualBox 4.3+
+* Ansible 2.1+
+
+### Quick setup
+
+Clone the project, `cd` into the directory, then run `./scripts/setup.sh` to create the Vagrant VM and then build the Docker containers.
+
+To start the servers during development:
+
+```bash
+$ vagrant ssh
+$ ./scripts/server.sh
+```
+
+### Testing
+
+To run linters and tests:
+
+```bash
+$ vagrant ssh
+$ ./scripts/test.sh
+```
+
+### Scripts
+
+| Name      | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `cibuild.sh` | Build application for staging or release                   |
+| `server.sh`  | Run `npm start` to run the development server              |
+| `setup.sh`   | Bring up the VM, then install Node.js dependencies         |
+| `infra.sh`   | Execute Terraform subcommands with remote state management |
+| `test.sh`    | Run linters and tests                                      |
+| `update.sh`  | Install local Node.js dependencies                         |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 1.8"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = 2048
+    vb.cpus = 2
+  end
+
+  # Change working directory to /vagrant upon session start.
+  config.vm.provision "shell", inline: <<SCRIPT
+    if ! grep -q "cd /vagrant" "/home/vagrant/.bashrc"; then
+        echo "cd /vagrant" >> "/home/vagrant/.bashrc"
+    fi
+SCRIPT
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "deployment/ansible/mmw-micro.yml"
+    ansible.galaxy_role_file = "deployment/ansible/roles.yml"
+  end
+end

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,41 @@
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `mmw-stg`:
+
+```bash
+$ vagrant ssh
+vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile mmw-stg configure
+AWS Access Key ID [****************F2DQ]:
+AWS Secret Access Key [****************TLJ/]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ export MMW_MICRO_ENV="staging"
+vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="mmw-stg"
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,0 +1,12 @@
+---
+aws_region: "us-east-1"
+aws_profile: "mmw-stg"
+
+aws_cli_version: "1.10.67"
+
+nodejs_version: "4.6.0"
+nodejs_npm_version: "2.15.11"
+
+shellcheck_version: "0.3.*"
+
+terraform_version: "0.7.3"

--- a/deployment/ansible/mmw-micro.yml
+++ b/deployment/ansible/mmw-micro.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
+  roles:
+    - { role: "azavea.ntp" }
+    - { role: "azavea.nodejs" }
+    - { role: "azavea.terraform" }
+    - { role: "mmw-micro.environment" }
+    - { role: "mmw-micro.awscli" }
+    - { role: "mmw-micro.shellcheck" }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,0 +1,14 @@
+- src: azavea.ntp
+  version: 0.2.0
+
+- src: azavea.unzip
+  version: 0.1.2
+
+- src: azavea.terraform
+  version: 0.2.0
+
+- src: azavea.pip
+  version: 0.2.0
+
+- src: azavea.nodejs
+  version: 0.4.0

--- a/deployment/ansible/roles/mmw-micro.awscli/meta/main.yml
+++ b/deployment/ansible/roles/mmw-micro.awscli/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: azavea.pip }

--- a/deployment/ansible/roles/mmw-micro.awscli/tasks/main.yml
+++ b/deployment/ansible/roles/mmw-micro.awscli/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Install AWS Command Line Interface
+  pip: name=awscli version="{{ aws_cli_version }}"

--- a/deployment/ansible/roles/mmw-micro.environment/tasks/main.yml
+++ b/deployment/ansible/roles/mmw-micro.environment/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Set AWS_DEFAULT_REGION globally
+  lineinfile: dest=/etc/environment
+              regexp=^AWS_DEFAULT_REGION
+              line="AWS_DEFAULT_REGION={{ aws_region }}"
+
+- name: Set AWS_PROFILE globally
+  lineinfile: dest=/etc/environment
+              regexp=^AWS_PROFILE
+              line="AWS_PROFILE={{ aws_profile }}"

--- a/deployment/ansible/roles/mmw-micro.shellcheck/tasks/main.yml
+++ b/deployment/ansible/roles/mmw-micro.shellcheck/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install ShellCheck
+  apt: pkg="shellcheck={{ shellcheck_version }}"
+       state=present

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -1,0 +1,60 @@
+resource "aws_cloudfront_distribution" "mmw_micro" {
+  origin {
+    domain_name = "${aws_s3_bucket.mmw_micro.id}.s3.amazonaws.com"
+    origin_id   = "mmwMicroOriginEastId"
+  }
+
+  enabled             = true
+  comment             = "MMW Micro (${var.environment})"
+  default_root_object = "index.html"
+  retain_on_delete    = true
+
+  price_class = "PriceClass_All"
+  aliases     = ["${var.r53_public_hosted_zone_record}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "mmwMicroOriginEastId"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    # Only applies if the origin adds Cache-Control headers. The
+    # CloudFront default is also 0.
+    min_ttl = 0
+
+    # Five minutes, and only applies when the origin DOES NOT
+    # supply Cache-Control headers.
+    default_ttl = 300
+
+    # One day, but only applies if the origin adds Cache-Control
+    # headers. The CloudFront default is 31536000 (one year).
+    max_ttl = 86400
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${aws_s3_bucket.mmw_micro_logs.id}.s3.amazonaws.com"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${var.acm_certificate_arn}"
+    minimum_protocol_version = "TLSv1"
+    ssl_support_method       = "sni-only"
+  }
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "mmw_micro" {
+  zone_id = "${var.r53_public_hosted_zone_id}"
+  name    = "${var.r53_public_hosted_zone_record}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.mmw_micro.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.mmw_micro.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/deployment/terraform/policies/s3-read-only-anonymous-user.json
+++ b/deployment/terraform/policies/s3-read-only-anonymous-user.json
@@ -1,0 +1,12 @@
+{
+    "Version":"2012-10-17",
+    "Statement":[
+        {
+            "Sid":"S3ReadOnly",
+            "Effect":"Allow",
+            "Principal": "*",
+            "Action":"s3:GetObject",
+            "Resource":"arn:aws:s3:::${bucket}/*"
+        }
+    ]
+}

--- a/deployment/terraform/policies/s3-server-side-encryption.json
+++ b/deployment/terraform/policies/s3-server-side-encryption.json
@@ -1,0 +1,30 @@
+{
+	"Version": "2012-10-17",
+	"Id": "PutObjPolicy",
+	"Statement": [
+		{
+			"Sid": "DenyIncorrectEncryptionHeader",
+			"Effect": "Deny",
+			"Principal": "*",
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::${bucket}/*",
+			"Condition": {
+				"StringNotEquals": {
+					"s3:x-amz-server-side-encryption": "AES256"
+				}
+			}
+		},
+		{
+			"Sid": "DenyUnEncryptedObjectUploads",
+			"Effect": "Deny",
+			"Principal": "*",
+			"Action": "s3:PutObject",
+			"Resource": "arn:aws:s3:::${bucket}/*",
+			"Condition": {
+				"Null": {
+					"s3:x-amz-server-side-encryption": "true"
+				}
+			}
+		}
+	]
+}

--- a/deployment/terraform/production.tfvars
+++ b/deployment/terraform/production.tfvars
@@ -1,0 +1,10 @@
+environment = "Production"
+
+logs_bucket = "production-mmw-micro-logs-us-east-1"
+origin_bucket = "production-mmw-micro-origin-us-east-1"
+config_bucket = "production-mmw-micro-config-us-east-1"
+
+acm_certificate_arn = "arn:aws:acm:us-east-1:146471631080:certificate/1e6187bb-062c-48d0-9bdd-0cc2e52e95bc"
+
+r53_public_hosted_zone_id = "ZRVL0TCLDP4BS"
+r53_public_hosted_zone_record = "micro.app.wikiwatershed.org"

--- a/deployment/terraform/provider.tf
+++ b/deployment/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/deployment/terraform/staging.tfvars
+++ b/deployment/terraform/staging.tfvars
@@ -1,0 +1,10 @@
+environment = "Staging"
+
+logs_bucket = "staging-mmw-micro-logs-us-east-1"
+origin_bucket = "staging-mmw-micro-origin-us-east-1"
+config_bucket = "staging-mmw-micro-config-us-east-1"
+
+acm_certificate_arn = "arn:aws:acm:us-east-1:956627593723:certificate/f45ec982-3bc7-4260-9e9f-c4ffac6b448e"
+
+r53_public_hosted_zone_id = "ZURQREPIGC39W"
+r53_public_hosted_zone_record = "micro.staging.app.wikiwatershed.org"

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,0 +1,38 @@
+#
+# S3 resources
+#
+data "template_file" "read_only_bucket_policy" {
+  template = "${file("policies/s3-read-only-anonymous-user.json")}"
+
+  vars {
+    bucket = "${var.origin_bucket}"
+  }
+}
+
+data "template_file" "server_side_encryption_policy" {
+  template = "${file("policies/s3-server-side-encryption.json")}"
+
+  vars {
+    bucket = "${var.config_bucket}"
+  }
+}
+
+resource "aws_s3_bucket" "mmw_micro" {
+  bucket = "${var.origin_bucket}"
+  policy = "${data.template_file.read_only_bucket_policy.rendered}"
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket" "mmw_micro_logs" {
+  bucket = "${var.logs_bucket}"
+  acl    = "log-delivery-write"
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "project" {
+  default = "MMW Micro"
+}
+
+variable "environment" {
+  default = "Staging"
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "logs_bucket" {}
+
+variable "config_bucket" {}
+
+variable "origin_bucket" {}
+
+variable "acm_certificate_arn" {}
+
+variable "r53_public_hosted_zone_id" {}
+
+variable "r53_public_hosted_zone_record" {}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "mmw-micro",
+    "version": "0.1.0",
+    "description": "A static micro site storm model.",
+    "main": "index.js",
+    "dependencies": {},
+    "devDependencies": {},
+    "scripts": {
+        "bundle": "echo \"Error: no bundle specified\" && exit 1",
+        "start": "echo \"Error: no start specified\" && exit 1",
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/WikiWatershed/mmw-micro.git"
+    },
+    "author": "Azavea Inc.",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/WikiWatershed/mmw-micro/issues"
+    },
+    "homepage": "https://github.com/WikiWatershed/mmw-micro#readme"
+}

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MMW_MICRO_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Script to execute within the CI environment.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        ./scripts/update.sh
+        ./scripts/test.sh
+        npm run bundle
+    fi
+fi

--- a/scripts/infra.sh
+++ b/scripts/infra.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MMW_MICRO_DEBUG}" ]]; then
+    set -x
+fi
+
+MMW_MICRO_ENV=${MMW_MICRO_ENV:-staging}
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Setup infrastructure resources required to support the site.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        pushd "$(dirname "$0")/../deployment/terraform"
+
+        # Stop Terraform from trying to apply incorrect state across environments
+        if [ -f ".terraform/terraform.tfstate" ] && ! grep -q "${MMW_MICRO_ENV}-mmw-micro-config-us-east-1" ".terraform/terraform.tfstate"; then
+            echo "ERROR: Incorrect target environment detected in Terraform state! Please run"
+            echo "       the following command before proceeding:"
+            echo
+            echo "  rm -rf deployment/terraform/.terraform"
+            echo
+            exit 1
+        fi
+
+        terraform remote config \
+                  -backend="s3" \
+                  -backend-config="region=us-east-1" \
+                  -backend-config="bucket=${MMW_MICRO_ENV}-mmw-micro-config-us-east-1" \
+                  -backend-config="key=terraform/state" \
+                  -backend-config="encrypt=true"
+
+        case "${1}" in
+            fmt)
+                terraform "$@"
+                ;;
+            taint)
+                terraform "$@"
+                ;;
+            plan)
+                terraform plan \
+                          -var-file="${MMW_MICRO_ENV}.tfvars" \
+                          -out="${MMW_MICRO_ENV}.tfplan"
+                aws s3 sync --dryrun --delete ../../dist "s3://${MMW_MICRO_ENV}-mmw-micro-origin-us-east-1"
+                ;;
+            apply)
+                terraform apply "${MMW_MICRO_ENV}.tfplan"
+                terraform remote push
+                aws s3 sync --delete ../../dist "s3://${MMW_MICRO_ENV}-mmw-micro-origin-us-east-1"
+                ;;
+            *)
+                echo "ERROR: I don't have support for that Terraform subcommand!"
+                exit 1
+                ;;
+        esac
+
+        popd
+    fi
+fi

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MMW_MICRO_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Start development server.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+      npm run start
+    fi
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MMW_MICRO_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Attempts to setup the project's development environment.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        vagrant up --provision
+        vagrant ssh -c "cd /vagrant && ./scripts/update.sh"
+    fi
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MMW_MICRO_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Run project tests.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        # Lint Bash scripts
+        if which shellcheck > /dev/null; then
+            shellcheck scripts/*.sh
+        fi
+
+        npm run test
+    fi
+fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MMW_MICRO_DEBUG}" ]]; then
+    set -x
+
+    NPM_ARGS=""
+else
+    NPM_ARGS="--quiet"
+fi
+
+function usage() {
+    echo -n \
+         "Usage: $(basename "$0")
+Updates application by installing Node.js dependencies.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        npm install ${NPM_ARGS}
+    fi
+fi


### PR DESCRIPTION
Add base project structure, including a stub NPM package configuration and scripts to manipulate the project. Also, add support for driving all of the AWS resources necessary to deploy the micro site across multiple environments.

Resolves parts of:
- https://github.com/WikiWatershed/model-my-watershed/issues/618
- https://github.com/WikiWatershed/model-my-watershed/issues/1483

---

**Testing**
- Execute the steps outlined in the `README` to see if bootstrapping the development environment works as expected.
- Execute the steps in the deployment `README` and ensure that the output matches the following:

``` bash
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/infra plan
/vagrant/deployment/terraform /vagrant
Remote configuration updated
Remote state configured and pulled.
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

data.template_file.read_only_bucket_policy: Refreshing state...
data.template_file.server_side_encryption_policy: Refreshing state...
aws_s3_bucket.mmw_micro_logs: Refreshing state... (ID: staging-mmw-micro-logs-us-east-1)
aws_s3_bucket.mmw_micro: Refreshing state... (ID: staging-mmw-micro-origin-us-east-1)
aws_cloudfront_distribution.mmw_micro: Refreshing state... (ID: EXUCNSJRVZI4W)
aws_route53_record.mmw_micro: Refreshing state... (ID: ZURQREPIGC39W_micro.staging.app.wikiwatershed.org_A)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything.
(dryrun) upload: ../../dist/index.html to s3://staging-mmw-micro-origin-us-east-1/index.html
/vagrant
```

**Note**: The last bit referencing `index.html` may not exist. I create a stub `index.html` file inside `dist/` to test.
