### PR TITLE
Tooltips and Popovers

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,7 +22,7 @@ then
         usage
     else
         # Lint Bash scripts
-        if which shellcheck > /dev/null; then
+        if command -v shellcheck > /dev/null; then
             shellcheck scripts/*.sh
         fi
 

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -220,84 +220,84 @@
 
                     <li id="thumb-open_water">
                         <a href="#land-open_water" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-11">
-                            <img src="img/thumb_openwater.png" alt="Open Water" data-name="open_water" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-11">
+                            <img src="img/thumb_openwater.png" alt="Open Water" data-name="open_water" data-container="body" data-toggle="popover" data-placement="right" data-category="nlcd-11">
                         </a>
                         <label>Water</label>
                     </li>
 
                     <li id="thumb-developed_open">
                         <a href="#land-developed_open" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-21">
-                            <img src="img/thumb_turfGrass.png" alt="Developed, Open Space" data-name="developed_open" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-21" >
+                            <img src="img/thumb_turfGrass.png" alt="Developed, Open Space" data-name="developed_open" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-21" >
                         </a>
                         <label>Developed-Open</label>
                     </li>
 
                     <li id="thumb-developed_low" class="active">
                         <a href="#land-developed_low" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-22">
-                            <img src="img/thumb_lir.png" alt="Developed, Low Intensity" data-name="developed_low" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-22" >
+                            <img src="img/thumb_lir.png" alt="Developed, Low Intensity" data-name="developed_low" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-22" >
                         </a>
                         <label>Developed-Low</label>
                     </li>
 
                     <li id="thumb-developed_med">
                         <a href="#land-developed_med" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-23">
-                            <img src="img/thumb_hir.png" alt="Developed, Medium Intensity" data-name="developed_med" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-23" >
+                            <img src="img/thumb_hir.png" alt="Developed, Medium Intensity" data-name="developed_med" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-23" >
                         </a>
                         <label>Developed-Med</label>
                     </li>
 
                     <li id="thumb-developed_high">
                         <a href="#land-developed_high" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-24">
-                            <img src="img/thumb_commercial.png" alt="Developed High Intensity" data-name="developed_high" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-24" >
+                            <img src="img/thumb_commercial.png" alt="Developed High Intensity" data-name="developed_high" data-container="body" data-toggle="popover" data-placement="right" data-category="nlcd-24" >
                         </a>
                         <label>Developed-High</label>
                     </li>
 
                     <li id="thumb-barren_land">
                         <a href="#land-barren_land" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-31">
-                            <img src="img/thumb_desert.png" alt="Barren Land (Rock/Sand/Clay)" data-name="barren_land" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-31" >
+                            <img src="img/thumb_desert.png" alt="Barren Land (Rock/Sand/Clay)" data-name="barren_land" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-31" >
                         </a>
                         <label>Barren Land</label>
                     </li>
 
                     <li id="thumb-deciduous_forest">
                         <a href="#land-deciduous_forest" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-41">
-                            <img src="img/thumb_forest.png" alt="Forest" data-container="body" data-name="deciduous_forest" data-toggle="popover" data-placement="left" data-category="nlcd-41" >
+                            <img src="img/thumb_forest.png" alt="Forest" data-container="body" data-name="deciduous_forest" data-toggle="popover" data-placement="bottom" data-category="nlcd-41" >
                         </a>
                         <label>Forest</label>
                     </li>
 
                     <li id="thumb-shrub">
                         <a href="#land-shrub" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-52">
-                            <img src="img/thumb_chaparral.png" alt="Shrub/Scrub" data-name="shrub" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-52" >
+                            <img src="img/thumb_chaparral.png" alt="Shrub/Scrub" data-name="shrub" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-52" >
                         </a>
                         <label>Shrub/Scrub</label>
                     </li>
 
                     <li id="thumb-grassland">
                         <a href="#land-grassland" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-71">
-                            <img src="img/thumb_grassland.png" alt="Grassland/Herbaceous" data-name="grassland" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-71" >
+                            <img src="img/thumb_grassland.png" alt="Grassland/Herbaceous" data-name="grassland" data-container="body" data-toggle="popover" data-placement="right" data-category="nlcd-71" >
                         </a>
                         <label>Grassland</label>
                     </li>
 
                     <li id="thumb-pasture">
                         <a href="#land-pasture" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-81">
-                            <img src="img/thumb_pasture.png" alt="Pasture/Hay" data-name="pasture" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-81" >
+                            <img src="img/thumb_pasture.png" alt="Pasture/Hay" data-name="pasture" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-81" >
                         </a>
                         <label>Pasture/Hay</label>
                     </li>
 
                     <li id="thumb-cultivated_crops">
                         <a href="#land-cultivated_crops" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-82">
-                            <img src="img/thumb_rowCrops.png" alt="Cultivated Crops" data-name="cultivated_crops" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-82" >
+                            <img src="img/thumb_rowCrops.png" alt="Cultivated Crops" data-name="cultivated_crops" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-82" >
                         </a>
                         <label>Crops</label>
                     </li>
 
                     <li id="thumb-woody_wetlands">
                         <a href="#land-woody_wetlands" aria-controls="filter-tab" role="tab" data-toggle="tab" class="nlcd-90">
-                            <img src="img/thumb_wetlands.png" alt="Wetlands" data-name="woody_wetlands" data-container="body" data-toggle="popover" data-placement="left" data-category="nlcd-90" >
+                            <img src="img/thumb_wetlands.png" alt="Wetlands" data-name="woody_wetlands" data-container="body" data-toggle="popover" data-placement="bottom" data-category="nlcd-90" >
                         </a>
                         <label>Wetlands</label>
                     </li>
@@ -313,28 +313,28 @@
 
                     <li id="thumb-sand" class="active"> <!-- Sand Thumb -->
                         <a href="#soil-sand" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-a">
-                            <img src="img/thumb_sand.png" alt="Sand" data-name="soil_a" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-a">
+                            <img src="img/thumb_sand.png" alt="Sand" data-name="soil_a" data-container="body" data-toggle="popover" data-placement="right" data-category="soil-a">
                         </a>
                         <label>A - High Infiltration</label>
                     </li>
 
                     <li id="thumb-loam"> <!-- Loam Thumb -->
                         <a href="#soil-loam" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-b">
-                            <img src="img/thumb_loam.png" alt="loam" data-name="soil_b" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-b">
+                            <img src="img/thumb_loam.png" alt="loam" data-name="soil_b" data-container="body" data-toggle="popover" data-placement="top" data-category="soil-b">
                         </a>
                         <label>B - Moderate Infiltration</label>
                     </li>
 
                     <li id="thumb-sandyClay"> <!-- Sandy Clay Thumb -->
                         <a href="#soil-sandyClay" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-c">
-                            <img src="img/thumb_sandyClay.png" alt="Sandy Clay" data-name="soil_c" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-c">
+                            <img src="img/thumb_sandyClay.png" alt="Sandy Clay" data-name="soil_c" data-container="body" data-toggle="popover" data-placement="top" data-category="soil-c">
                         </a>
                         <label>C - Slow Infiltration</label>
                     </li>
 
                     <li id="thumb-clayLoam"> <!-- Clay Loam Thumb -->
                         <a href="#soil-clayLoam" aria-controls="filter-tab" role="tab" data-toggle="tab" class="soil-d">
-                            <img src="img/thumb_clayLoam.png" alt="Clay Loam" data-name="soil_d" data-container="body" data-toggle="popover" data-placement="left" data-category="soil-d">
+                            <img src="img/thumb_clayLoam.png" alt="Clay Loam" data-name="soil_d" data-container="body" data-toggle="popover" data-placement="top" data-category="soil-d">
                         </a>
                         <label>D - Very Slow Infiltration</label>
                     </li>

--- a/src/app/js/src/main.js
+++ b/src/app/js/src/main.js
@@ -131,7 +131,7 @@ var initBootstrap = function() {
         var $popover = $(popover),
             category = $popover.data('category') || 'default',
             template = '<div class="popover" role="tooltip">' +
-                '<div class="arrow"></div>' +
+                '<div class="arrow ' + ' ' + category + '"></div>' +
                 '<h3 class="popover-title ' + ' ' + category + '"></h3>' +
                 '<div class="popover-content"></div></div>',
             entry = modificationConfig[$popover.data('name')],

--- a/src/app/js/src/main.js
+++ b/src/app/js/src/main.js
@@ -142,7 +142,7 @@ var initBootstrap = function() {
             };
 
         if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
-            $popover.popover(_.extend(options, {triggger:'click'}));
+            $popover.popover(_.extend(options, {trigger:'click'}));
 
             $popover.click(function() {
                 $('[data-toggle="popover"]').not(this).popover('hide'); //all but this

--- a/src/app/sass/pages/_water-balance.scss
+++ b/src/app/sass/pages/_water-balance.scss
@@ -509,6 +509,72 @@
   border-radius: 0;
   border: solid 1px $black-12;
   padding: 0px;
+
+  &.bottom .arrow {
+    &.nlcd-11::after {
+      border-bottom-color: $nlcd-11;
+    }
+
+    &.nlcd-21::after {
+      border-bottom-color: $nlcd-21;
+    }
+
+    &.nlcd-22::after {
+      border-bottom-color: $nlcd-22;
+    }
+
+    &.nlcd-23::after {
+      border-bottom-color: $nlcd-23;
+    }
+
+    &.nlcd-24::after {
+      border-bottom-color: $nlcd-24;
+    }
+
+    &.nlcd-31::after {
+      border-bottom-color: $nlcd-31;
+    }
+
+    &.nlcd-41::after {
+      border-bottom-color: $nlcd-41;
+    }
+
+    &.nlcd-52::after {
+      border-bottom-color: $nlcd-52;
+    }
+
+    &.nlcd-71::after {
+      border-bottom-color: $nlcd-71;
+    }
+
+    &.nlcd-81::after {
+      border-bottom-color: $nlcd-81;
+    }
+
+    &.nlcd-82::after {
+      border-bottom-color: $nlcd-82;
+    }
+
+    &.nlcd-90::after {
+      border-bottom-color: $nlcd-90;
+    }
+
+    &.soil-a::after {
+      border-bottom-color: $soil-a;
+    }
+
+    &.soil-b::after {
+      border-bottom-color: $soil-b;
+    }
+
+    &.soil-c::after {
+      border-bottom-color: $soil-c;
+    }
+
+    &.soil-d::after {
+      border-bottom-color: $soil-d;
+    }
+  }
 }
 
 .popover-title {

--- a/src/app/sass/pages/_water-balance.scss
+++ b/src/app/sass/pages/_water-balance.scss
@@ -164,7 +164,6 @@
     bottom: 30px;
     padding-bottom: 48px;
     white-space: normal;
-    z-index: 200;
 
     .column {
       position: relative;


### PR DESCRIPTION
## Overview

Ensures that water column tooltips are always on top. Also ensures that thumbnail popovers do not obscure the main content.

See commit messages for details.

Connects #17 
Connects #19 

## Demo

Tooltips on top:

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/1430060/86062773-6e9d6d80-ba37-11ea-9ed7-db5198b61e40.png">

Non-obscuring popovers:

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/1430060/86062797-7c52f300-ba37-11ea-92f1-2ba8fd2b5b03.png">

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/1430060/86062807-84129780-ba37-11ea-93ff-7150434f44cf.png">

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/1430060/86062819-8bd23c00-ba37-11ea-8d4f-8ff5cc3a8078.png">

## Testing Instructions

* Check out this branch
* `./scripts/setup.sh`
* `vagrant ssh -c 'cd /vagrant && ./scripts/bundle.sh --debug'`
* `vagrant ssh -c 'cd /vagrant && ./scripts/server.sh'`
* Make the viewport narrow enough to bring the water column close to the Evapotranspiration and Infiltration label wells
* Hover over the water column
  - [x] Ensure the tooltips aren't obscured
* Hover over the thumbnails
  - [x] Ensure the main content is never obscured